### PR TITLE
Fixed TclError: grab failed: window not viewable

### DIFF
--- a/interfaces/cython/cantera/mixmaster/UnitChooser.py
+++ b/interfaces/cython/cantera/mixmaster/UnitChooser.py
@@ -69,7 +69,14 @@ class UnitVar(Frame):
         b=Button(self.new,text='OK',command=self.finished, default=ACTIVE)
         b.grid(column=c, row=r)
 
-        self.new.grab_set()
+        while 1: 
+            try: 
+                self.new.grab_set() 
+                break 
+            except TclError: 
+                sys.exc_traceback = None 
+                self.new.after(100)
+
         self.new.focus_set()
         self.new.wait_window()
 


### PR DESCRIPTION
Before:
When changing the units, one can create as many instances of UnitChooser as the pc allowed.

Now:
When we are changing Units, this fix blocks the input to the original window, so the only way back to the original window is by closing the Unit window (the new Toplevel window).

Original Error:
![Screenshot from 2019-03-10 18-55-45](https://user-images.githubusercontent.com/43749533/54085763-7c714000-4367-11e9-8975-b974107bff5a.png)
